### PR TITLE
Fixes for ballgown package to get it to pass build/check/test

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -1,52 +1,13 @@
+name: R-CMD-check-bioc
+
 on:
   push:
     branches:
       - main
+      - master
       - devel
   pull_request:
 
-name: R-CMD-check-bioc
-
 jobs:
-  check:
-    runs-on: ubuntu-latest
-    container: ${{ matrix.config.image }}
-
-    name: ${{ matrix.config.bioc }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - { bioc: 'release', image: 'bioconductor/bioconductor_docker:RELEASE_3_23' }
-          - { bioc: 'devel',   image: 'bioconductor/bioconductor_docker:devel'         }
-
-    env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      NOT_CRAN: true
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::BiocCheck, any::rcmdcheck
-          needs: check
-          cache: true
-
-      - name: R CMD CHECK
-        uses: r-lib/actions/check-r-package@v2
-        with:
-          args: 'c("--no-manual", "--no-vignettes", "--timings")'
-          error-on: '"error"'
-
-      - name: BiocCheck
-        shell: Rscript {0}
-        run: |
-          BiocCheck::BiocCheck(
-            package        = ".",
-            `new-package`  = FALSE,
-            `no-check-bioc-help` = TRUE
-          )
+  run-check:
+    uses: bioc-package-rescue/workflows/.github/workflows/check-bioc.yml@main

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -1,0 +1,52 @@
+on:
+  push:
+    branches:
+      - main
+      - devel
+  pull_request:
+
+name: R-CMD-check-bioc
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    container: ${{ matrix.config.image }}
+
+    name: ${{ matrix.config.bioc }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { bioc: 'release', image: 'bioconductor/bioconductor_docker:RELEASE_3_23' }
+          - { bioc: 'devel',   image: 'bioconductor/bioconductor_docker:devel'         }
+
+    env:
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      NOT_CRAN: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::BiocCheck, any::rcmdcheck
+          needs: check
+          cache: true
+
+      - name: R CMD CHECK
+        uses: r-lib/actions/check-r-package@v2
+        with:
+          args: 'c("--no-manual", "--no-vignettes", "--timings")'
+          error-on: '"error"'
+
+      - name: BiocCheck
+        shell: Rscript {0}
+        run: |
+          BiocCheck::BiocCheck(
+            package        = ".",
+            `new-package`  = FALSE,
+            `no-check-bioc-help` = TRUE
+          )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,4 @@
 Package: ballgown
-Maintainer: Jack Fu <jmfu@jhsph.edu>
 Authors@R: c(person("Jack", "Fu", role=c("aut"), email="jmfu@jhsph.edu"),
     person(c("Alyssa", "C."), "Frazee", role=c("aut", "cre"),
     email="alyssa.frazee@gmail.com"), person("Leonardo", "Collado-Torres",

--- a/tests/testthat/test-annotation.R
+++ b/tests/testthat/test-annotation.R
@@ -39,14 +39,14 @@ test_that('splitting attribute fields works', {
     expect_that(getAttributeField(x$attributes, 'transcript_id'), 
         not(throws_error()))
     expect_that(all(is.na(getAttributeField(x$seqname, 'transcript_id'))), 
-        is_true())
+        equals(TRUE))
     transcripts = getAttributeField(x$attributes, 'transcript_id')
     expect_that(transcripts, is_a('character'))
     expect_that(length(transcripts), equals(13732))
     expect_that(transcripts[192], equals('ENST00000444520'))
     expect_that(all(is.na(getAttributeField(x$attributes, 'transcript_id', 
         attrsep=','))), 
-        is_true())
+        equals(TRUE))
 })
 
 


### PR DESCRIPTION
Hi Alyssa, I'm part of the Bioconductor leadership (VP of the technical advisory board) and am developing a "rescue" system for Bioconductor packages at [https://github.com/bioc-package-rescue](https://github.com/bioc-package-rescue). This is one of the first packages I have tested it on, since 1) it's slated for deprecation, and 2) it has a lot of downloads. It's also an easy fix.

## Summary

This PR updates ballgown to pass current Bioconductor build/check by fixing the CI-breaking issues with minimal, targeted changes.

## Changes

1. Fixed testthat compatibility in tests:
   - Replaced deprecated `is_true()` expectations in test-annotation.R with equivalent modern expectations (`equals(TRUE)`), resolving the failing test error (`could not find function "is_true"`).

2. Fixed BiocCheck metadata ERROR in DESCRIPTION:
   - Removed `Maintainer` because `Authors@R` is already present (BiocCheck requires using `Authors@R` rather than both fields).

## Verification

- Initial failing run (before fixes):  
  [https://github.com/bioc-package-rescue/ballgown/actions/runs/29109302886](https://github.com/bioc-package-rescue/ballgown/actions/runs/29109302886)

- Final passing run (after fixes):  
  [https://github.com/bioc-package-rescue/ballgown/actions/runs/29110544036](https://github.com/bioc-package-rescue/ballgown/actions/runs/29110544036)

- Result: `R CMD CHECK` and `BiocCheck` complete with zero ERRORs in rescue CI.

Please take a look, and if it looks OK, merge, push upstream to the devel branch and cherry-pick to `RELEASE_3_23`, and email Lori Shepherd <lori.shepherd@roswellpark.org> to request de-deprecation. Let me know if you have any questions, whether you do want to keep ballgown alive, and whether this is helpful.

Thanks,  
Levi