### PR TITLE
Fix R CMD check and BiocCheck errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,4 @@
 Package: ballgown
-Maintainer: Jack Fu <jmfu@jhsph.edu>
 Authors@R: c(person("Jack", "Fu", role=c("aut"), email="jmfu@jhsph.edu"),
     person(c("Alyssa", "C."), "Frazee", role=c("aut", "cre"),
     email="alyssa.frazee@gmail.com"), person("Leonardo", "Collado-Torres",

--- a/tests/testthat/test-annotation.R
+++ b/tests/testthat/test-annotation.R
@@ -39,14 +39,14 @@ test_that('splitting attribute fields works', {
     expect_that(getAttributeField(x$attributes, 'transcript_id'), 
         not(throws_error()))
     expect_that(all(is.na(getAttributeField(x$seqname, 'transcript_id'))), 
-        is_true())
+        equals(TRUE))
     transcripts = getAttributeField(x$attributes, 'transcript_id')
     expect_that(transcripts, is_a('character'))
     expect_that(length(transcripts), equals(13732))
     expect_that(transcripts[192], equals('ENST00000444520'))
     expect_that(all(is.na(getAttributeField(x$attributes, 'transcript_id', 
         attrsep=','))), 
-        is_true())
+        equals(TRUE))
 })
 
 


### PR DESCRIPTION
Hi Stein, I am part of the Bioconductor leadership (VP of the technical advisory board) and am developing a "rescue" system for Bioconductor packages at https://github.com/bioc-package-rescue. This package is a good candidate because it is slated for deprecation and still has substantial downloads.

This PR includes only source fixes (no GitHub Actions workflow file):
- replace deprecated testthat is_true() usage in tests
- remove Maintainer from DESCRIPTION when Authors@R is present (BiocCheck error)

Validation run from rescue fork:
https://github.com/bioc-package-rescue/ballgown/actions/runs/29110544036

If this looks good, please merge, push upstream to devel, cherry-pick to RELEASE_3_23, and email Lori Shepherd <lori.shepherd@roswellpark.org> to request de-deprecation.

Thanks,
Levi